### PR TITLE
fix rescue_from example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1030,7 +1030,7 @@ You can rescue a `Grape::Exceptions::ValidationErrors` and respond with a custom
 
 ```ruby
 format :json
-subject.rescue_from Grape::Exceptions::ValidationErrors do |e|
+rescue_from Grape::Exceptions::ValidationErrors do |e|
   rack_response e.to_json, 400
 end
 ```


### PR DESCRIPTION
Hello,

I found the `rescue_from` sample in readme.md has a typo and fixed it.